### PR TITLE
add Pokémon dropdown with abilities fetch and caching

### DIFF
--- a/frontend/src/pages/projects/apiExamples/examples/PokemonDropdown.jsx
+++ b/frontend/src/pages/projects/apiExamples/examples/PokemonDropdown.jsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from "react";
+
+const PokemonDropdown = () => {
+  const [pokemons, setPokemons] = useState([]);
+  const [pokemonChache, setPokemonCache] = useState({});
+  const [selectedPokemon, setSelectedPokemon] = useState(null);
+  const [abilities, setAbilities] = useState([]);
+
+  useEffect(() => {
+    const fetchPokemon = async () => {
+      try {
+        const response = await fetch("https://pokeapi.co/api/v2/pokemon/");
+        const pokemonData = await response.json();
+        setPokemons(pokemonData.results);
+      } catch (error) {
+        console.error("Error fetching pokemon data:", error);
+      }
+    };
+    fetchPokemon();
+  }, []);
+
+  const handlePokemonSelection = async (url, name) => {
+    if (pokemonChache[name]) {
+      setAbilities(pokemonChache[name].abilities);
+    } else {
+      try {
+        const response = await fetch(url);
+        const data = await response.json();
+        setAbilities(data.abilities);
+        setPokemonCache((prevCache) => ({
+          ...prevCache,
+          [name]: data,
+        }));
+        console.log(selectedPokemon);
+      } catch (error) {
+        console.error("Error fetching pokemon details:", error);
+      }
+    }
+  };
+
+  return (
+    <div>
+      <h1>Pokemon Dropdown Example</h1>
+      <label htmlFor="pokemon-dropdown">Select a Pokemon:</label>
+      <select
+        name="pokemon-dropdown"
+        id="pokemon-dropdown"
+        onChange={(e) => {
+          const pokemonUrl = e.target.value;
+          const selectedName = e.target.options[e.target.selectedIndex].text;
+          if (!pokemonUrl) {
+            setSelectedPokemon(null);
+            setAbilities([]);
+            return;
+          }
+          setSelectedPokemon(pokemonUrl);
+          handlePokemonSelection(pokemonUrl, selectedName);
+        }}
+      >
+        <option value="">Please choose an option</option>
+        {pokemons.map((pokemon) => (
+          <option key={pokemon.name} value={pokemon.url}>
+            {pokemon.name}
+          </option>
+        ))}
+      </select>
+      {selectedPokemon === null ? (
+        <p>Please choose the pokemon from the list to see abilities</p>
+      ) : (
+        <fieldset>
+          <legend>Pokemon Abilities:</legend>
+          <ul aria-live="polite">
+            {abilities.map((abilityObj) => (
+              <li key={abilityObj.ability.name}>{abilityObj.ability.name}</li>
+            ))}
+          </ul>
+        </fieldset>
+      )}
+    </div>
+  );
+};
+
+export default PokemonDropdown;

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -12,6 +12,7 @@ import StarwarsCharacters from "../pages/projects/apiExamples/examples/StarwarsC
 import ReactChallengesView from "../pages/projects/react-challenges/ReactChallengesView";
 import AccessibilityComponentsView from "../pages/projects/accessibility-components/AccessibilityComponentsView";
 import ProductLisitingPageWithAsc from "../pages/projects/apiExamples/examples/ProductLisitingPageWithAsc";
+import PokemonDropdown from "../pages/projects/apiExamples/examples/PokemonDropdown";
 
 export const routes = [
   { path: "/about", element: <About /> },
@@ -31,6 +32,10 @@ export const routes = [
   {
     path: "/apiExampleView/Product-Listing-Page",
     element: <ProductLisitingPageWithAsc />,
+  },
+  {
+    path: "/apiExampleView/Pokemon-Dropdown",
+    element: <PokemonDropdown />,
   },
   { path: "/projects/react-challenges", element: <ReactChallengesView /> },
   {


### PR DESCRIPTION
- Implemented a React component that fetches a list of Pokémon from the PokéAPI.
- Added a dropdown to select a Pokémon, with a placeholder option for guidance.
- When a Pokémon is selected, its abilities are fetched from the API.
- Implemented caching to avoid repeated API calls for the same Pokémon.
- Displayed abilities inside an accessible <fieldset> with a <legend>.
- Show a placeholder message when no Pokémon is selected.
- Added error handling for API calls and used async/await for cleaner code.
- Ensured accessibility with proper labels and aria-live for dynamic updates.